### PR TITLE
NEW: Full support for excluded IPs

### DIFF
--- a/exclusion/exclusion.go
+++ b/exclusion/exclusion.go
@@ -1,0 +1,67 @@
+package exclusion
+
+import (
+	"fmt"
+
+	"github.com/aporeto-inc/trireme-kubernetes/kubernetes"
+	"github.com/aporeto-inc/trireme/supervisor"
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/client/cache"
+)
+
+// Watcher is maintaining the state of the ExclusionList.
+type Watcher struct {
+	kubeClient            kubernetes.Client
+	triremeNets           []string
+	excluder              supervisor.Excluder
+	serviceController     *cache.Controller
+	serviceControllerStop chan struct{}
+}
+
+func NewWatcher(triremeNets []string, kubeClient kubernetes.Client, excluder supervisor.Excluder) Watcher {
+
+	watcher := Watcher{
+		kubeClient:  kubeClient,
+		triremeNets: triremeNets,
+		excluder:    excluder,
+	}
+
+	watcher.serviceControllerStop = make(chan struct{})
+	_, watcher.serviceController = kubeClient.CreateServiceController(
+		watcher.addService,
+		watcher.deleteService,
+		watcher.updateService)
+
+	return watcher
+}
+
+// Start launches the Exclusion Watcher
+// Blocking. Use go...
+func (w *Watcher) Start() {
+	w.serviceController.Run(w.serviceControllerStop)
+}
+
+// Stop stops the Excluder updater.
+func (w *Watcher) Stop() {
+	w.serviceControllerStop <- struct{}{}
+}
+
+func (w *Watcher) addService(addedAPIStruct *api.Service) error {
+	if addedAPIStruct.Spec.ClusterIP == "" {
+		return nil
+	}
+	fmt.Printf("Processing Cluster IP: %s", addedAPIStruct.Spec.ClusterIP)
+	endpoints, _ := w.kubeClient.Endpoints(addedAPIStruct.GetName(), addedAPIStruct.GetNamespace())
+	for _, set := range endpoints.Subsets {
+		fmt.Printf("Addresses: %+v ", set.Addresses)
+	}
+	return nil
+}
+
+func (w *Watcher) deleteService(deletedAPIStruct *api.Service) error {
+	return nil
+}
+
+func (w *Watcher) updateService(oldAPIStruct, updatedAPIStruct *api.Service) error {
+	return nil
+}

--- a/exclusion/exclusion.go
+++ b/exclusion/exclusion.go
@@ -2,9 +2,12 @@ package exclusion
 
 import (
 	"fmt"
+	"net"
+	"sync"
 
 	"github.com/aporeto-inc/trireme-kubernetes/kubernetes"
 	"github.com/aporeto-inc/trireme/supervisor"
+	"github.com/golang/glog"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/client/cache"
 )
@@ -12,18 +15,30 @@ import (
 // Watcher is maintaining the state of the ExclusionList.
 type Watcher struct {
 	kubeClient            kubernetes.Client
-	triremeNets           []string
+	triremeNets           []*net.IPNet
 	excluder              supervisor.Excluder
+	excludedIPs           map[string]struct{}
 	serviceController     *cache.Controller
 	serviceControllerStop chan struct{}
+	mutex                 sync.Mutex
 }
 
-func NewWatcher(triremeNets []string, kubeClient kubernetes.Client, excluder supervisor.Excluder) Watcher {
-
-	watcher := Watcher{
+// NewWatcher generates a new Watcher
+func NewWatcher(triremeNets []string, kubeClient kubernetes.Client, excluder supervisor.Excluder) (*Watcher, error) {
+	ipNets := []*net.IPNet{}
+	for _, triremeNet := range triremeNets {
+		_, parsedNet, err := net.ParseCIDR(triremeNet)
+		if err != nil {
+			return nil, fmt.Errorf("Error parsing Trireme Subnet: %s", err)
+		}
+		ipNets = append(ipNets, parsedNet)
+	}
+	watcher := &Watcher{
 		kubeClient:  kubeClient,
-		triremeNets: triremeNets,
+		triremeNets: ipNets,
 		excluder:    excluder,
+		excludedIPs: map[string]struct{}{},
+		mutex:       sync.Mutex{},
 	}
 
 	watcher.serviceControllerStop = make(chan struct{})
@@ -32,7 +47,7 @@ func NewWatcher(triremeNets []string, kubeClient kubernetes.Client, excluder sup
 		watcher.deleteService,
 		watcher.updateService)
 
-	return watcher
+	return watcher, nil
 }
 
 // Start launches the Exclusion Watcher
@@ -50,18 +65,70 @@ func (w *Watcher) addService(addedAPIStruct *api.Service) error {
 	if addedAPIStruct.Spec.ClusterIP == "" {
 		return nil
 	}
-	fmt.Printf("Processing Cluster IP: %s", addedAPIStruct.Spec.ClusterIP)
+	fmt.Printf("Processing Added Cluster IP: %s", addedAPIStruct.Spec.ClusterIP)
 	endpoints, _ := w.kubeClient.Endpoints(addedAPIStruct.GetName(), addedAPIStruct.GetNamespace())
 	for _, set := range endpoints.Subsets {
-		fmt.Printf("Addresses: %+v ", set.Addresses)
+		for _, ip := range set.Addresses {
+			glog.V(2).Infof("Checking if endpoint IP %s (ClusterIP %s ) is part of TriremeNets ", ip, addedAPIStruct.Spec.ClusterIP)
+			if !w.isInTriremeNets(ip.IP) {
+				return w.excludeServiceIP(addedAPIStruct.Spec.ClusterIP)
+			}
+		}
 	}
 	return nil
 }
 
 func (w *Watcher) deleteService(deletedAPIStruct *api.Service) error {
+	if w.isIPExcluded(deletedAPIStruct.Spec.ClusterIP) {
+		return w.restoreServiceIP(deletedAPIStruct.Spec.ClusterIP)
+	}
 	return nil
 }
 
 func (w *Watcher) updateService(oldAPIStruct, updatedAPIStruct *api.Service) error {
 	return nil
+}
+
+func (w *Watcher) excludeServiceIP(ip string) error {
+	glog.V(2).Infof("Excluding IP %s", ip)
+	if err := w.excluder.AddExcludedIP(ip + "/32"); err != nil {
+		return fmt.Errorf("Error excluding IP: %s", err)
+	}
+	w.mutex.Lock()
+	w.excludedIPs[ip] = struct{}{}
+	w.mutex.Unlock()
+	return nil
+}
+
+func (w *Watcher) restoreServiceIP(ip string) error {
+	glog.V(2).Infof("Restoring IP %s", ip)
+
+	if err := w.excluder.RemoveExcludedIP(ip + "/32"); err != nil {
+		return fmt.Errorf("Error restoring IP: %s", err)
+	}
+	w.mutex.Lock()
+	delete(w.excludedIPs, ip)
+	w.mutex.Unlock()
+	return nil
+}
+
+func (w *Watcher) isIPExcluded(ip string) bool {
+	w.mutex.Lock()
+	_, ok := w.excludedIPs[ip]
+	w.mutex.Unlock()
+	return ok
+}
+
+func (w *Watcher) isInTriremeNets(ip string) bool {
+	glog.V(2).Infof("Testing IP %s", ip)
+	testip := net.ParseIP(ip)
+	if testip == nil {
+		return false
+	}
+	for _, subnet := range w.triremeNets {
+		if subnet.Contains(testip) {
+			return true
+		}
+	}
+	return false
 }

--- a/kubernetes/client.go
+++ b/kubernetes/client.go
@@ -20,7 +20,7 @@ type Client struct {
 }
 
 // NewClient Generate and initialize a Trireme Client object
-func NewClient(kubeconfig string, namespace string, nodename string) (*Client, error) {
+func NewClient(kubeconfig string, nodename string) (*Client, error) {
 	Client := &Client{}
 	Client.localNode = nodename
 

--- a/kubernetes/client.go
+++ b/kubernetes/client.go
@@ -88,6 +88,16 @@ func (c *Client) PodRules(podName string, namespace string) (*[]extensions.Netwo
 	return allRules, nil
 }
 
+// Endpoints return the list of all the IngressRules that apply to the pod.
+func (c *Client) Endpoints(service string, namespace string) (*api.Endpoints, error) {
+	// Step1: Get all the rules associated with this Pod.
+	endpoints, err := c.kubeClient.Endpoints(namespace).Get(service)
+	if err != nil {
+		return nil, fmt.Errorf("Couldn't get endpoints for service %s from Kubernetes API: %s", service, err)
+	}
+	return endpoints, nil
+}
+
 // PodLabels returns the list of all labels associated with a pod.
 func (c *Client) PodLabels(podName string, namespace string) (map[string]string, error) {
 	targetPod, err := c.kubeClient.Pods(namespace).Get(podName)

--- a/kubernetes/handler.go
+++ b/kubernetes/handler.go
@@ -9,6 +9,8 @@ import (
 	"k8s.io/kubernetes/pkg/runtime"
 )
 
+const errorLogLevel = 2
+
 // CreateResourceController creates a controller for a specific ressource and namespace.
 // Input
 func CreateResourceController(client cache.Getter, resource string, namespace string, apiStruct runtime.Object, selector fields.Selector,
@@ -25,23 +27,23 @@ func CreateResourceController(client cache.Getter, resource string, namespace st
 }
 
 // CreateNamespaceController creates a controller specifically for Namespaces.
-func (c *Client) CreateNamespaceController(client cache.Getter,
+func (c *Client) CreateNamespaceController(
 	addFunc func(addedApiStruct *api.Namespace) error, deleteFunc func(deletedApiStruct *api.Namespace) error, updateFunc func(oldApiStruct, updatedApiStruct *api.Namespace) error) (cache.Store, *cache.Controller) {
-	return CreateResourceController(client, "namespaces", "", &api.Namespace{}, fields.Everything(),
+	return CreateResourceController(c.KubeClient().Core().RESTClient(), "namespaces", "", &api.Namespace{}, fields.Everything(),
 		func(addedApiStruct interface{}) {
 			if err := addFunc(addedApiStruct.(*api.Namespace)); err != nil {
-				glog.V(2).Infof("Error while handling Add NameSpace: %s ", err)
+				glog.V(errorLogLevel).Infof("Error while handling Add NameSpace: %s ", err)
 			}
 		},
 		func(deletedApiStruct interface{}) {
 			if err := deleteFunc(deletedApiStruct.(*api.Namespace)); err != nil {
-				glog.V(2).Infof("Error while handling Delete NameSpace: %s ", err)
+				glog.V(errorLogLevel).Infof("Error while handling Delete NameSpace: %s ", err)
 
 			}
 		},
 		func(oldApiStruct, updatedApiStruct interface{}) {
 			if err := updateFunc(oldApiStruct.(*api.Namespace), updatedApiStruct.(*api.Namespace)); err != nil {
-				glog.V(2).Infof("Error while handling Update NameSpace: %s ", err)
+				glog.V(errorLogLevel).Infof("Error while handling Update NameSpace: %s ", err)
 
 			}
 		})
@@ -54,17 +56,17 @@ func (c *Client) CreateLocalPodController(namespace string,
 	return CreateResourceController(c.KubeClient().Core().RESTClient(), "pods", namespace, &api.Pod{}, c.localNodeSelector(),
 		func(addedApiStruct interface{}) {
 			if err := addFunc(addedApiStruct.(*api.Pod)); err != nil {
-				glog.V(2).Infof("Error while handling Add Pod: %s ", err)
+				glog.V(errorLogLevel).Infof("Error while handling Add Pod: %s ", err)
 			}
 		},
 		func(deletedApiStruct interface{}) {
 			if err := deleteFunc(deletedApiStruct.(*api.Pod)); err != nil {
-				glog.V(2).Infof("Error while handling Delete Pod: %s ", err)
+				glog.V(errorLogLevel).Infof("Error while handling Delete Pod: %s ", err)
 			}
 		},
 		func(oldApiStruct, updatedApiStruct interface{}) {
 			if err := updateFunc(oldApiStruct.(*api.Pod), updatedApiStruct.(*api.Pod)); err != nil {
-				glog.V(2).Infof("Error while handling Update Pod: %s ", err)
+				glog.V(errorLogLevel).Infof("Error while handling Update Pod: %s ", err)
 			}
 		})
 }
@@ -75,17 +77,17 @@ func (c *Client) CreateNetworkPoliciesController(namespace string,
 	return CreateResourceController(c.KubeClient().Extensions().RESTClient(), "networkpolicies", namespace, &extensions.NetworkPolicy{}, fields.Everything(),
 		func(addedApiStruct interface{}) {
 			if err := addFunc(addedApiStruct.(*extensions.NetworkPolicy)); err != nil {
-				glog.V(2).Infof("Error while handling Add NetworkPolicy: %s ", err)
+				glog.V(errorLogLevel).Infof("Error while handling Add NetworkPolicy: %s ", err)
 			}
 		},
 		func(deletedApiStruct interface{}) {
 			if err := deleteFunc(deletedApiStruct.(*extensions.NetworkPolicy)); err != nil {
-				glog.V(2).Infof("Error while handling Delete NetworkPolicy: %s ", err)
+				glog.V(errorLogLevel).Infof("Error while handling Delete NetworkPolicy: %s ", err)
 			}
 		},
 		func(oldApiStruct, updatedApiStruct interface{}) {
 			if err := updateFunc(oldApiStruct.(*extensions.NetworkPolicy), updatedApiStruct.(*extensions.NetworkPolicy)); err != nil {
-				glog.V(2).Infof("Error while handling Update NetworkPolicy: %s ", err)
+				glog.V(errorLogLevel).Infof("Error while handling Update NetworkPolicy: %s ", err)
 			}
 		})
 }
@@ -96,17 +98,38 @@ func (c *Client) CreateNodeController(
 	return CreateResourceController(c.KubeClient().Core().RESTClient(), "nodes", "", &api.Node{}, fields.Everything(),
 		func(addedApiStruct interface{}) {
 			if err := addFunc(addedApiStruct.(*api.Node)); err != nil {
-				glog.V(2).Infof("Error while handling Add Node: %s ", err)
+				glog.V(errorLogLevel).Infof("Error while handling Add Node: %s ", err)
 			}
 		},
 		func(deletedApiStruct interface{}) {
 			if err := deleteFunc(deletedApiStruct.(*api.Node)); err != nil {
-				glog.V(2).Infof("Error while handling Delete Node: %s ", err)
+				glog.V(errorLogLevel).Infof("Error while handling Delete Node: %s ", err)
 			}
 		},
 		func(oldApiStruct, updatedApiStruct interface{}) {
 			if err := updateFunc(oldApiStruct.(*api.Node), updatedApiStruct.(*api.Node)); err != nil {
-				glog.V(2).Infof("Error while handling Update Node: %s ", err)
+				glog.V(errorLogLevel).Infof("Error while handling Update Node: %s ", err)
+			}
+		})
+}
+
+// CreateServiceController creates a controller specifically for NetworkPolicies.
+func (c *Client) CreateServiceController(
+	addFunc func(addedApiStruct *api.Service) error, deleteFunc func(deletedApiStruct *api.Service) error, updateFunc func(oldApiStruct, updatedApiStruct *api.Service) error) (cache.Store, *cache.Controller) {
+	return CreateResourceController(c.KubeClient().Core().RESTClient(), "services", "", &api.Service{}, fields.Everything(),
+		func(addedApiStruct interface{}) {
+			if err := addFunc(addedApiStruct.(*api.Service)); err != nil {
+				glog.V(errorLogLevel).Infof("Error while handling Add Node: %s ", err)
+			}
+		},
+		func(deletedApiStruct interface{}) {
+			if err := deleteFunc(deletedApiStruct.(*api.Service)); err != nil {
+				glog.V(errorLogLevel).Infof("Error while handling Delete Node: %s ", err)
+			}
+		},
+		func(oldApiStruct, updatedApiStruct interface{}) {
+			if err := updateFunc(oldApiStruct.(*api.Service), updatedApiStruct.(*api.Service)); err != nil {
+				glog.V(errorLogLevel).Infof("Error while handling Update Node: %s ", err)
 			}
 		})
 }

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"os/signal"
 
@@ -75,7 +76,11 @@ func main() {
 	// Register the IPExcluder to the Policy
 	kubernetesPolicy.SetExcluder(excluder)
 
-	exclusionWatcher := exclusion.NewWatcher(config.TriremeNets, *kubernetesPolicy.KubernetesClient, excluder)
+	exclusionWatcher, err := exclusion.NewWatcher(config.TriremeNets, *kubernetesPolicy.KubernetesClient, excluder)
+	if err != nil {
+		log.Fatalf("Error creating the exclusion Watcher: %s", err)
+	}
+
 	go exclusionWatcher.Start()
 
 	// Start all the go routines.

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/aporeto-inc/trireme-kubernetes/auth"
 	"github.com/aporeto-inc/trireme-kubernetes/config"
+	"github.com/aporeto-inc/trireme-kubernetes/exclusion"
 	"github.com/aporeto-inc/trireme-kubernetes/resolver"
 
 	"github.com/aporeto-inc/trireme"
@@ -73,6 +74,9 @@ func main() {
 	kubernetesPolicy.SetPolicyUpdater(trireme)
 	// Register the IPExcluder to the Policy
 	kubernetesPolicy.SetExcluder(excluder)
+
+	exclusionWatcher := exclusion.NewWatcher(config.TriremeNets, *kubernetesPolicy.KubernetesClient, excluder)
+	go exclusionWatcher.Start()
 
 	// Start all the go routines.
 	trireme.Start()

--- a/resolver/policy.go
+++ b/resolver/policy.go
@@ -287,7 +287,7 @@ func (k *KubernetesPolicy) deactivateNamespace(namespace *api.Namespace) error {
 // Run is blocking. Use go
 func (k *KubernetesPolicy) Run() {
 	k.stopAll = make(chan struct{})
-	_, nsController := k.KubernetesClient.CreateNamespaceController(k.KubernetesClient.KubeClient().Core().RESTClient(),
+	_, nsController := k.KubernetesClient.CreateNamespaceController(
 		k.addNamespace,
 		k.deleteNamespace,
 		k.updateNamespace)


### PR DESCRIPTION
This added feature allows the Trireme Kubernetes agent to automatically detect when  service IP is redirecting to a Non-Trireme endpoint.
This is an issue as the Service-IP range is typically given at startup as being the "Trireme" range. Therefore if serviceIPs redirect to non-Trireme endpoint, those specific service IPs need to be excluded.