### PR TITLE
New: update link to Trireme-Lib

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Trireme-Kubernetes is a simple, straightforward implementation of Kubernetes Net
 
 Trireme-Kubernetes builds upon a powerful concept of identity based on standard Kubernetes tags.
 
-It is based on the [Trireme](https://github.com/aporeto-inc/trireme) Zero-Trust library.
+It is based on the [Trireme Zero-Trust library](https://github.com/aporeto-inc/trireme-lib).
 
 ----
 


### PR DESCRIPTION
Since `Trireme` was formally renamed to `Trireme-Lib`, this PR address the changes in the README files.