### PR TITLE
Move to Kubernetes Client 6.0.0 and resolve policy bug from Kubepox

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # trireme-kubernetes
 
-
 [![Twitter URL](https://img.shields.io/badge/twitter-follow-blue.svg)](https://twitter.com/aporeto_trireme) [![Slack URL](https://img.shields.io/badge/slack-join-green.svg)](https://triremehq.slack.com/messages/general/) [![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0) [![Documentation](https://img.shields.io/badge/docs-godoc-blue.svg)](https://godoc.org/github.com/aporeto-inc/trireme)
 [![Analytics](https://ga-beacon.appspot.com/UA-90327502-1/welcome-page)](https://github.com/igrigorik/ga-beacon)
 

--- a/glide.yaml
+++ b/glide.yaml
@@ -2,7 +2,7 @@ package: github.com/aporeto-inc/trireme-kubernetes
 import:
   ## Aporeto
 - package: github.com/aporeto-inc/trireme-lib
-  version: add_debug_remote
+  version: ^7.x
 - package: github.com/aporeto-inc/kubepox
 - package: github.com/aporeto-inc/trireme-csr
 - package: github.com/aporeto-inc/trireme-statistics

--- a/glide.yaml
+++ b/glide.yaml
@@ -17,7 +17,7 @@ import:
   - pkg/selection
   - pkg/watch
 - package: k8s.io/client-go
-  version: ^5.0.0
+  version: ^6.0.0
   subpackages:
   - kubernetes
   - rest

--- a/glide.yaml
+++ b/glide.yaml
@@ -2,7 +2,7 @@ package: github.com/aporeto-inc/trireme-kubernetes
 import:
   ## Aporeto
 - package: github.com/aporeto-inc/trireme-lib
-  version: ^7.x
+  version: ^6.x
 - package: github.com/aporeto-inc/kubepox
 - package: github.com/aporeto-inc/trireme-csr
 - package: github.com/aporeto-inc/trireme-statistics

--- a/resolver/selector.go
+++ b/resolver/selector.go
@@ -302,6 +302,10 @@ func aclEgressRules(rule networking.NetworkPolicyEgressRule) ([]policy.IPRule, e
 }
 
 func generateIngressRulesList(ingressKubeRules *[]networking.NetworkPolicyIngressRule, podNamespace string, allNamespaces *api.NamespaceList, tags *policy.TagStore, ips policy.ExtendedMap, triremeNets []string, betaPolicies bool) ([]policy.TagSelector, []policy.IPRule, error) {
+	if ingressKubeRules == nil {
+		return rulesAndACLsAllowAll()
+	}
+
 	if !betaPolicies && len(*ingressKubeRules) == 0 {
 		return rulesAndACLsAllowAll()
 	}
@@ -352,6 +356,10 @@ func generateIngressRulesList(ingressKubeRules *[]networking.NetworkPolicyIngres
 }
 
 func generateEgressRulesList(egressKubeRules *[]networking.NetworkPolicyEgressRule, podNamespace string, allNamespaces *api.NamespaceList, tags *policy.TagStore, ips policy.ExtendedMap, triremeNets []string, betaPolicies bool) ([]policy.TagSelector, []policy.IPRule, error) {
+	if egressKubeRules == nil {
+		return rulesAndACLsAllowAll()
+	}
+
 	if !betaPolicies && len(*egressKubeRules) == 0 {
 		return rulesAndACLsAllowAll()
 	}


### PR DESCRIPTION
This PR moves to the latest Client-Go in v 6.0.0

It also resolves the buggy case where KubePox would return a nil set of list for egress or ingress.