### PR TITLE
Use new trireme-csr with auto-generated client code

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -3,7 +3,7 @@
 ##
 [[constraint]]
   name = "github.com/aporeto-inc/trireme-csr"
-  branch = "master"
+  branch = "code-generator"
 
 [[constraint]]
   name = "github.com/aporeto-inc/trireme-statistics"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -3,7 +3,7 @@
 ##
 [[constraint]]
   name = "github.com/aporeto-inc/trireme-csr"
-  branch = "code-generator"
+  branch = "master"
 
 [[constraint]]
   name = "github.com/aporeto-inc/trireme-statistics"

--- a/auth/pki.go
+++ b/auth/pki.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"github.com/aporeto-inc/trireme-csr/certificates"
-	certificateclient "github.com/aporeto-inc/trireme-csr/client"
+	certificateclient "github.com/aporeto-inc/trireme-csr/pkg/client/clientset/versioned"
 
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -28,12 +28,10 @@ func LoadPKI(nodeName string, kubeconfigPath string) (*TriremePKI, error) {
 		panic("Error generating Kubeconfig " + err.Error())
 	}
 
-	certClient, _, err := certificateclient.NewClient(kubeconfig)
+	certManager, err := certificates.NewCertManager(nodeName, certificateclient.NewForConfigOrDie(kubeconfig))
 	if err != nil {
-		panic("Error creating REST Kube Client for certificates: " + err.Error())
+		panic("Failed to create CertManager " + err.Error())
 	}
-
-	certManager, err := certificates.NewCertManager(nodeName, certClient)
 
 	err = certManager.GeneratePrivateKey()
 	if err != nil {

--- a/deployment/trireme/certificate-crd.yaml
+++ b/deployment/trireme/certificate-crd.yaml
@@ -4,8 +4,8 @@ metadata:
   name: certificates.certmanager.k8s.io
 spec:
   group: certmanager.k8s.io
-  version: v1alpha1
+  version: v1alpha2
   names:
     kind: Certificate
     plural: certificates
-  scope: Namespaced
+  scope: Cluster


### PR DESCRIPTION
This is needed once https://github.com/aporeto-inc/trireme-csr/pull/25 has been merged into master to fix https://github.com/aporeto-inc/trireme-csr/issues/20.

**NOTE:** merge the PR in trireme-csr first!
**NOTE:** once merged, change the `Gopkg.toml` here back to master branch for `trireme-csr` before merge.